### PR TITLE
add buffer support (WIP)

### DIFF
--- a/__tests__/01_word_files_ole_test.js
+++ b/__tests__/01_word_files_ole_test.js
@@ -2,14 +2,14 @@ const fs = require('fs');
 const path = require('path');
 const { Buffer } = require('buffer');
 
-const oleDoc = require('../lib/ole-doc').OleCompoundDoc;
+const oleDoc = require('../lib/ole-doc');
 
 const files = fs.readdirSync(path.resolve(__dirname, "data"));
 describe.each(files.filter((f) => f.match(/\.doc$/)).map((x) => [x]))(
   `Word file %s`, (file) => {
     it('can be opened correctly', (done) => {
       const filename = path.resolve(__dirname, `data/${file}`);
-      const doc = new oleDoc(filename);
+      const doc = new oleDoc.OleCompoundDocFile(filename);
       doc.on('err', (err) => done(err));
       doc.on('ready', () => done());
       doc.read();
@@ -17,7 +17,7 @@ describe.each(files.filter((f) => f.match(/\.doc$/)).map((x) => [x]))(
 
     it('generates a valid Word stream', (done) => {
       const filename = path.resolve(__dirname, `data/${file}`);
-      const doc = new oleDoc(filename);
+      const doc = new oleDoc.OleCompoundDocFile(filename);
 
       doc.on('err', err => done(err));
       doc.on('ready', () => {

--- a/lib/ole-doc.js
+++ b/lib/ole-doc.js
@@ -33,6 +33,10 @@ var async = require('async');
 var _ = require('underscore');
 var es = require('event-stream');
 
+var errorMessage = {
+   notValidCompoundDoc: 'Not a valid compound document.'
+}
+
 function Header() {
 };
 
@@ -63,16 +67,32 @@ Header.prototype.load = function( buffer ) {
    return true;
 };
 
-function AllocationTable(doc) {
+function AllocationTableBase(doc) {
    this._doc = doc;
-}
+};
 
-AllocationTable.SecIdFree       = -1;
-AllocationTable.SecIdEndOfChain = -2;
-AllocationTable.SecIdSAT        = -3;
-AllocationTable.SecIdMSAT       = -4;
+AllocationTableBase.SecIdFree       = -1;
+AllocationTableBase.SecIdEndOfChain = -2;
+AllocationTableBase.SecIdSAT        = -3;
+AllocationTableBase.SecIdMSAT       = -4;
 
-AllocationTable.prototype.load = function(secIds, callback) {
+AllocationTableBase.prototype.getSecIdChain = function(startSecId) {
+   var secId = startSecId;
+   var secIds = [];
+   while ( secId != AllocationTableBase.SecIdEndOfChain ) {
+      secIds.push( secId );
+      secId = this._table[secId];
+   }
+
+   return secIds;
+};
+
+function AllocationTableFile(doc) {
+   AllocationTableBase.call( this, doc );
+};
+util.inherits(AllocationTableFile, AllocationTableBase);
+
+AllocationTableFile.prototype.load = function(secIds, callback) {
    var self = this;
    var doc = self._doc;
    var header = doc._header;
@@ -88,70 +108,38 @@ AllocationTable.prototype.load = function(secIds, callback) {
    });
 };
 
-AllocationTable.prototype.getSecIdChain = function(startSecId) {
-   var secId = startSecId;
-   var secIds = [];
-   while ( secId != AllocationTable.SecIdEndOfChain ) {
-      secIds.push( secId );
-      secId = this._table[secId];
-   }
-
-   return secIds;
+function AllocationTableBuffer(doc) {
+   AllocationTableBase.call( this, doc );
 };
+util.inherits(AllocationTableBuffer, AllocationTableBase);
 
-function DirectoryTree(doc) {
-   this._doc = doc;
-}
-
-DirectoryTree.EntryTypeEmpty   = 0;
-DirectoryTree.EntryTypeStorage = 1;
-DirectoryTree.EntryTypeStream  = 2;
-DirectoryTree.EntryTypeRoot    = 5;
-
-DirectoryTree.NodeColorRed   = 0;
-DirectoryTree.NodeColorBlack = 1;
-
-DirectoryTree.Leaf = -1;
-
-DirectoryTree.prototype.load = function( secIds, callback ) {
-   var self = this;
+AllocationTableBuffer.prototype.load = function(secIds) {
    var doc = this._doc;
+   var header = doc._header;
 
-   doc._readSectors( secIds, function(buffer) {
+   this._table = new Array( secIds.length * ( header.secSize / 4 ) );
 
-      var count = buffer.length / 128;
-      self._entries = new Array( count );
-      var i = 0;
-      for( i = 0; i < count; i++ )
-      {
-         var offset = i * 128;
-
-         var nameLength = Math.max( buffer.readInt16LE( 64 + offset ) - 1, 0 );
-
-         var entry = {};
-         entry.name = buffer.toString('utf16le', 0 + offset, nameLength + offset );
-         entry.type = buffer.readInt8( 66 + offset );
-         entry.nodeColor = buffer.readInt8( 67 + offset );
-         entry.left = buffer.readInt32LE( 68 + offset );
-         entry.right = buffer.readInt32LE( 72 + offset );
-         entry.storageDirId = buffer.readInt32LE( 76 + offset );
-         entry.secId = buffer.readInt32LE( 116 + offset );
-         entry.size = buffer.readInt32LE( 120 + offset );
-
-         self._entries[i] = entry;
-      }
-
-      self.root = _.find( self._entries, function(entry) {
-         return entry.type === DirectoryTree.EntryTypeRoot;
-      });
-
-      self._buildHierarchy( self.root );
-
-      callback();
-   });
+   var buffer = doc._readSectors(secIds);
+   for ( var i = 0; i < buffer.length / 4; i += 1 ) {
+      this._table[i] = buffer.readInt32LE( i * 4 );
+   }
 };
 
-DirectoryTree.prototype._buildHierarchy = function( storageEntry ) {
+function DirectoryTreeBase(doc) {
+   this._doc = doc;
+};
+
+DirectoryTreeBase.EntryTypeEmpty   = 0;
+DirectoryTreeBase.EntryTypeStorage = 1;
+DirectoryTreeBase.EntryTypeStream  = 2;
+DirectoryTreeBase.EntryTypeRoot    = 5;
+
+DirectoryTreeBase.NodeColorRed   = 0;
+DirectoryTreeBase.NodeColorBlack = 1;
+
+DirectoryTreeBase.Leaf = -1;
+
+DirectoryTreeBase.prototype._buildHierarchy = function( storageEntry ) {
    var self = this;
    var childIds = this._getChildIds( storageEntry );
 
@@ -161,10 +149,10 @@ DirectoryTree.prototype._buildHierarchy = function( storageEntry ) {
    _.each( childIds, function( childId ) {
       var childEntry = self._entries[childId];
       var name = childEntry.name;
-      if ( childEntry.type === DirectoryTree.EntryTypeStorage ) {
+      if ( childEntry.type === DirectoryTreeBase.EntryTypeStorage ) {
          storageEntry.storages[name] = childEntry;
       }
-      if ( childEntry.type === DirectoryTree.EntryTypeStream ) {
+      if ( childEntry.type === DirectoryTreeBase.EntryTypeStream ) {
          storageEntry.streams[name] = childEntry;
       }
    });
@@ -174,16 +162,16 @@ DirectoryTree.prototype._buildHierarchy = function( storageEntry ) {
    });
 };
 
-DirectoryTree.prototype._getChildIds = function( storageEntry ) {
+DirectoryTreeBase.prototype._getChildIds = function( storageEntry ) {
    var self = this;
    var childIds = [];
 
    function visit( visitEntry ) {
-      if ( visitEntry.left !== DirectoryTree.Leaf ) {
+      if ( visitEntry.left !== DirectoryTreeBase.Leaf ) {
          childIds.push( visitEntry.left );
          visit( self._entries[visitEntry.left] );
       }
-      if ( visitEntry.right !== DirectoryTree.Leaf ) {
+      if ( visitEntry.right !== DirectoryTreeBase.Leaf ) {
          childIds.push( visitEntry.right );
          visit( self._entries[visitEntry.right] );
       }
@@ -196,6 +184,58 @@ DirectoryTree.prototype._getChildIds = function( storageEntry ) {
    }
 
    return childIds;
+};
+
+DirectoryTreeBase.prototype._loadBuffer = function ( buffer ) {
+   var count = buffer.length / 128;
+   this._entries = new Array( count );
+   for( var i = 0; i < count; i++ )
+   {
+      var offset = i * 128;
+
+      var nameLength = Math.max( buffer.readInt16LE( 64 + offset ) - 1, 0 );
+
+      var entry = {};
+      entry.name = buffer.toString('utf16le', 0 + offset, nameLength + offset );
+      entry.type = buffer.readInt8( 66 + offset );
+      entry.nodeColor = buffer.readInt8( 67 + offset );
+      entry.left = buffer.readInt32LE( 68 + offset );
+      entry.right = buffer.readInt32LE( 72 + offset );
+      entry.storageDirId = buffer.readInt32LE( 76 + offset );
+      entry.secId = buffer.readInt32LE( 116 + offset );
+      entry.size = buffer.readInt32LE( 120 + offset );
+
+      this._entries[i] = entry;
+   }
+
+   this.root = _.find( this._entries, function(entry) {
+      return entry.type === DirectoryTreeBase.EntryTypeRoot;
+   });
+
+   this._buildHierarchy( this.root );
+};
+
+function DirectoryTreeFile(doc) {
+   DirectoryTreeBase.call( this, doc );
+};
+util.inherits(DirectoryTreeFile, DirectoryTreeBase);
+
+DirectoryTreeFile.prototype.load = function( secIds, callback ) {
+   var self = this;
+
+   self._doc._readSectors( secIds, function(buffer) {
+      self._loadBuffer( buffer );
+      callback();
+   });
+};
+
+function DirectoryTreeBuffer(doc) {
+   DirectoryTreeBase.call( this, doc );
+};
+util.inherits(DirectoryTreeBuffer, DirectoryTreeBase);
+
+DirectoryTreeBuffer.prototype.load = function( secIds ) {
+   this._loadBuffer( this._doc._readSectors( secIds ) );
 };
 
 function Storage( doc, dirEntry ) {
@@ -257,25 +297,56 @@ Storage.prototype.stream = function( streamName ) {
 //   this._dirEntry = dirEntry;
 //};
 
-function OleCompoundDoc( filename ) {
+function OleCompoundDocBase() {
    EventEmitter.call(this);
 
-   this._filename = filename;
    this._skipBytes = 0;
 };
-util.inherits(OleCompoundDoc, EventEmitter);
+util.inherits(OleCompoundDocBase, EventEmitter);
 
-OleCompoundDoc.prototype.read = function() {
+OleCompoundDocBase.prototype.read = function() {
    this._read();
 };
 
-OleCompoundDoc.prototype.readWithCustomHeader = function( size, callback ) {
+OleCompoundDocBase.prototype.readWithCustomHeader = function( size, callback ) {
    this._skipBytes = size;
    this._customHeaderCallback = callback;
    this._read();
 };
 
-OleCompoundDoc.prototype._read = function() {
+OleCompoundDocBase.prototype._getFileOffsetForSec = function( secId ) {
+   var secSize = this._header.secSize;
+   return this._skipBytes + (secId + 1) * secSize;  // Skip past the header sector
+};
+
+OleCompoundDocBase.prototype._getFileOffsetForShortSec = function( shortSecId ) {
+   var shortSecSize = this._header.shortSecSize;
+   var shortStreamOffset = shortSecId * shortSecSize;
+
+   var secSize = this._header.secSize;
+   var secIdIndex = Math.floor( shortStreamOffset / secSize );
+   var secOffset = shortStreamOffset % secSize;
+   var secId = this._shortStreamSecIds[secIdIndex];
+
+   return this._getFileOffsetForSec( secId ) + secOffset;
+};
+
+OleCompoundDocBase.prototype.storage = function( storageName ) {
+   return this._rootStorage.storage( storageName );
+};
+
+OleCompoundDocBase.prototype.stream = function( streamName ) {
+   return this._rootStorage.stream( streamName );
+};
+
+function OleCompoundDocFile( filename ) {
+   OleCompoundDocBase.call(this);
+
+   this._filename = filename;
+};
+util.inherits(OleCompoundDocFile, OleCompoundDocBase);
+
+OleCompoundDocFile.prototype._read = function() {
    var series = [
       this._openFile.bind(this),
       this._readHeader.bind(this),
@@ -302,7 +373,7 @@ OleCompoundDoc.prototype._read = function() {
    );
 };
 
-OleCompoundDoc.prototype._openFile = function( callback ) {
+OleCompoundDocFile.prototype._openFile = function( callback ) {
    var self = this;
    fs.open( this._filename, 'r', 0o666, function(err, fd) {
       if( err ) {
@@ -315,7 +386,7 @@ OleCompoundDoc.prototype._openFile = function( callback ) {
    });
 };
 
-OleCompoundDoc.prototype._readCustomHeader = function(callback) {
+OleCompoundDocFile.prototype._readCustomHeader = function(callback) {
    var self = this;
    var buffer = new Buffer(this._skipBytes);
    fs.read( self._fd, buffer, 0, this._skipBytes, 0, function(err, bytesRead, buffer) {
@@ -331,7 +402,7 @@ OleCompoundDoc.prototype._readCustomHeader = function(callback) {
    });
 };
 
-OleCompoundDoc.prototype._readHeader = function(callback) {
+OleCompoundDocFile.prototype._readHeader = function(callback) {
    var self = this;
    var buffer = new Buffer(512);
    fs.read( this._fd, buffer, 0, 512, 0 + this._skipBytes, function(err, bytesRead, buffer) {
@@ -342,7 +413,7 @@ OleCompoundDoc.prototype._readHeader = function(callback) {
 
       var header = self._header = new Header();
       if ( !header.load( buffer ) ) {
-         self.emit('err', 'Not a valid compound document.');
+         self.emit('err', errorMessage.notValidCompoundDoc);
          return;
       }
 
@@ -350,7 +421,7 @@ OleCompoundDoc.prototype._readHeader = function(callback) {
    });
 };
 
-OleCompoundDoc.prototype._readMSAT = function(callback) {
+OleCompoundDocFile.prototype._readMSAT = function(callback) {
    var self = this;
    var header = self._header;
 
@@ -400,11 +471,11 @@ OleCompoundDoc.prototype._readMSAT = function(callback) {
    );
 };
 
-OleCompoundDoc.prototype._readSector = function(secId, callback) {
+OleCompoundDocFile.prototype._readSector = function(secId, callback) {
    this._readSectors( [ secId ], callback );
 };
 
-OleCompoundDoc.prototype._readSectors = function(secIds, callback) {
+OleCompoundDocFile.prototype._readSectors = function(secIds, callback) {
    var self = this;
    var header = self._header;
    var buffer = new Buffer( secIds.length * header.secSize );
@@ -436,11 +507,11 @@ OleCompoundDoc.prototype._readSectors = function(secIds, callback) {
    );
 };
 
-OleCompoundDoc.prototype._readShortSector = function(secId, callback) {
+OleCompoundDocFile.prototype._readShortSector = function(secId, callback) {
    this._readShortSectors( [ secId ], callback );
 };
 
-OleCompoundDoc.prototype._readShortSectors = function(secIds, callback) {
+OleCompoundDocFile.prototype._readShortSectors = function(secIds, callback) {
    var self = this;
    var header = self._header;
    var buffer = new Buffer( secIds.length * header.shortSecSize );
@@ -472,17 +543,17 @@ OleCompoundDoc.prototype._readShortSectors = function(secIds, callback) {
    );
 };
 
-OleCompoundDoc.prototype._readSAT = function(callback) {
+OleCompoundDocFile.prototype._readSAT = function(callback) {
    var self = this;
-   self._SAT = new AllocationTable(self);
+   self._SAT = new AllocationTableFile(self);
 
    self._SAT.load( self._MSAT, callback );
 };
 
-OleCompoundDoc.prototype._readSSAT = function(callback) {
+OleCompoundDocFile.prototype._readSSAT = function(callback) {
    var self = this;
    var header = self._header;
-   self._SSAT = new AllocationTable(self);
+   self._SSAT = new AllocationTableFile(self);
 
    var secIds = self._SAT.getSecIdChain( header.SSATSecId );
    if ( secIds.length != header.SSATSize ) {
@@ -493,11 +564,11 @@ OleCompoundDoc.prototype._readSSAT = function(callback) {
    self._SSAT.load( secIds, callback);
 };
 
-OleCompoundDoc.prototype._readDirectoryTree = function(callback) {
+OleCompoundDocFile.prototype._readDirectoryTree = function(callback) {
    var self = this;
    var header = self._header;
 
-   self._directoryTree = new DirectoryTree(this);
+   self._directoryTree = new DirectoryTreeFile(this);
 
    var secIds = self._SAT.getSecIdChain( header.dirSecId );
    self._directoryTree.load( secIds, function() {
@@ -510,29 +581,155 @@ OleCompoundDoc.prototype._readDirectoryTree = function(callback) {
    });
 };
 
-OleCompoundDoc.prototype._getFileOffsetForSec = function( secId ) {
-   var secSize = this._header.secSize;
-   return this._skipBytes + (secId + 1) * secSize;  // Skip past the header sector
+function OleCompoundDocBuffer( buf ) {
+   OleCompoundDocBase.call(this);
+
+   this._buf = buf;
+};
+util.inherits(OleCompoundDocBuffer, OleCompoundDocBase);
+
+OleCompoundDocBuffer.prototype._read = function() {
+   try {
+      if ( this._skipBytes != 0 ) {
+        var customHeaderCbResult = this._readCustomHeader();
+        if (!customHeaderCbResult) return;
+      }
+
+      var readHeaderResult = this._readHeader();
+      if ( !readHeaderResult ) return;
+
+      this._readMSAT();
+      this._readSAT();
+
+      var readSSATResult = this._readSSAT();
+      if ( !readSSATResult ) return;
+
+      this._readDirectoryTree();
+      this.emit('ready');
+   } catch (e) {
+      this.emit('err', e);
+   }
 };
 
-OleCompoundDoc.prototype._getFileOffsetForShortSec = function( shortSecId ) {
-   var shortSecSize = this._header.shortSecSize;
-   var shortStreamOffset = shortSecId * shortSecSize;
+OleCompoundDocBuffer.prototype._readCustomHeader = function() {
+   var buffer = new Buffer(this._skipBytes);
 
-   var secSize = this._header.secSize;
-   var secIdIndex = Math.floor( shortStreamOffset / secSize );
-   var secOffset = shortStreamOffset % secSize;
-   var secId = this._shortStreamSecIds[secIdIndex];
-
-   return this._getFileOffsetForSec( secId ) + secOffset;
+   return this._customHeaderCallback(buffer);
 };
 
-OleCompoundDoc.prototype.storage = function( storageName ) {
-   return this._rootStorage.storage( storageName );
+OleCompoundDocBuffer.prototype._readHeader = function() {
+   var start = this._skipBytes;
+   var buffer = this._buf.slice(start, start + 512);
+   var header = this._header = new Header();
+
+   if (!header.load(buffer)) {
+      this.emit('err', errorMessage.notValidCompoundDoc);
+      return false;
+   }
+
+   return true;
 };
 
-OleCompoundDoc.prototype.stream = function( streamName ) {
-   return this._rootStorage.stream( streamName );
+OleCompoundDocBuffer.prototype._readMSAT = function() {
+   var header = this._header;
+
+   this._MSAT = header.partialMSAT.slice(0);
+   this._MSAT.length = header.SATSize;
+
+   if( header.SATSize <= 109 || header.MSATSize == 0 ) {
+      return;
+   }
+
+   var buffer = new Buffer( header.secSize );
+   var currMSATIndex = 109;
+   var secId = header.MSATSecId;
+
+   for ( var i = 0; i < header.MSATSize; i += 1 ) {
+      var sectorBuffer = this._readSector(secId);
+
+      for ( var s = 0; s < header.secSize - 4; s += 4 ) {
+         if ( currMSATIndex >= header.SATSize ) break;
+         else this._MSAT[currMSATIndex] = sectorBuffer.readInt32LE( s );
+
+         currMSATIndex += 1;
+      }
+
+      secId = sectorBuffer.readInt32LE( header.secSize - 4 );
+   }
 };
 
-exports.OleCompoundDoc = OleCompoundDoc;
+OleCompoundDocBuffer.prototype._readSector = function(secId) {
+   return this._readSectors( [ secId ] );
+};
+
+OleCompoundDocBuffer.prototype._readSectors = function(secIds) {
+   var header = this._header;
+   var buffer = new Buffer( secIds.length * header.secSize );
+
+   for (var i = 0; i < secIds.length; i += 1) {
+      var targetStart = i * header.secSize;
+      var sourceStart = this._getFileOffsetForSec( secIds[i] );
+      var sourceEnd = sourceStart + header.secSize;
+
+      this._buf.copy( buffer, targetStart, sourceStart, sourceEnd );
+   }
+
+   return buffer;
+};
+
+OleCompoundDocBuffer.prototype._readShortSector = function(secId) {
+   return this._readShortSectors( [ secId ] );
+};
+
+OleCompoundDocBuffer.prototype._readShortSectors = function(secIds, callback) {
+   var header = this._header;
+   var buffer = new Buffer( secIds.length * header.shortSecSize );
+
+   for ( var i = 0; i < secIds.length; i += 1 ) {
+      var targetStart = i * header.shortSecSize;
+      var sourceStart = this._getFileOffsetForShortSec( secIds[i] );
+      var sourceEnd = sourceStart + header.shortSecSize;
+
+      this._buf.copy( buffer, targetStart, sourceStart, sourceEnd );
+   }
+
+   return buffer;
+};
+
+OleCompoundDocBuffer.prototype._readSAT = function() {
+   var self = this;
+   self._SAT = new AllocationTableBuffer(self);
+
+   self._SAT.load( self._MSAT );
+};
+
+OleCompoundDocBuffer.prototype._readSSAT = function(callback) {
+   var self = this;
+   var header = self._header;
+   self._SSAT = new AllocationTableBuffer(self);
+
+   var secIds = self._SAT.getSecIdChain( header.SSATSecId );
+   if ( secIds.length != header.SSATSize ) {
+      self.emit('err', 'Invalid Short Sector Allocation Table');
+      return false;
+   }
+
+   self._SSAT.load( secIds );
+   return true;
+};
+
+OleCompoundDocBuffer.prototype._readDirectoryTree = function() {
+   var header = this._header;
+
+   this._directoryTree = new DirectoryTreeBuffer(this);
+
+   var secIds = this._SAT.getSecIdChain( header.dirSecId );
+   this._directoryTree.load( secIds );
+
+   var rootEntry = this._directoryTree.root;
+   this._rootStorage = new Storage( this, rootEntry );
+   this._shortStreamSecIds = this._SAT.getSecIdChain( rootEntry.secId );
+};
+
+exports.OleCompoundDocFile = OleCompoundDocFile;
+exports.OleCompoundDocBuffer = OleCompoundDocBuffer;

--- a/lib/word.js
+++ b/lib/word.js
@@ -7,7 +7,7 @@
  */
 const { Buffer } =     require('buffer');
 
-const oleDoc =         require('./ole-doc').OleCompoundDoc;
+const oleDoc =         require('./ole-doc');
 
 const filters =        require('./filters');         // eslint-disable-line no-unused-vars
 const translations =   require('./translations');    // eslint-disable-line no-unused-vars
@@ -26,8 +26,8 @@ var WordExtractor = (function() {
   let addUnicodeText = undefined;
   WordExtractor = class WordExtractor {
     static initClass() {
-  
-  
+
+
       //# Given an OLE stream, returns all the data in a buffer,
       //# as a promise.
       streamBuffer = stream =>
@@ -38,11 +38,14 @@ var WordExtractor = (function() {
           return stream.on('end', () => resolve(Buffer.concat(chunks)));
         })
       ;
-  
-  
-      extractDocument = filename =>
+
+
+      extractDocument = filenameOrbuffer =>
         new Promise(function(resolve, reject) {
-          const document = new oleDoc(filename);
+          const document = Buffer.isBuffer(filenameOrbuffer)
+            ? new oleDoc.OleCompoundDocBuffer(filenameOrbuffer)
+            : new oleDoc.OleCompoundDocFile(filenameOrbuffer);
+
           document.on('err', error => {
             return reject(error);
           });
@@ -52,11 +55,11 @@ var WordExtractor = (function() {
           return document.read();
         })
       ;
-  
-  
+
+
       documentStream = (document, stream) => Promise.resolve(document.stream(stream));
-  
-  
+
+
       writeBookmarks = function(buffer, tableBuffer, result) {
         const fcSttbfBkmk = buffer.readUInt32LE(0x0142);
         const lcbSttbfBkmk = buffer.readUInt32LE(0x0146);
@@ -64,25 +67,25 @@ var WordExtractor = (function() {
         const lcbPlcfBkf = buffer.readUInt32LE(0x014e);
         const fcPlcfBkl = buffer.readUInt32LE(0x0152);
         const lcbPlcfBkl = buffer.readUInt32LE(0x0156);
-  
+
         if (lcbSttbfBkmk === 0) { return; }
-  
+
         const sttbfBkmk = tableBuffer.slice(fcSttbfBkmk, fcSttbfBkmk + lcbSttbfBkmk);
         const plcfBkf = tableBuffer.slice(fcPlcfBkf, fcPlcfBkf + lcbPlcfBkf);
         const plcfBkl = tableBuffer.slice(fcPlcfBkl, fcPlcfBkl + lcbPlcfBkl);
-  
+
         const fcExtend = sttbfBkmk.readUInt16LE(0);
         const cData = sttbfBkmk.readUInt16LE(2);       // eslint-disable-line no-unused-vars
         const cbExtra = sttbfBkmk.readUInt16LE(4);     // eslint-disable-line no-unused-vars
-  
+
         if (fcExtend !== 0xffff) {
           throw new Error("Internal error: unexpected single-byte bookmark data");
         }
-  
+
         let offset = 6;
         const index = 0;
         const bookmarks = {};                          // eslint-disable-line no-unused-vars
-  
+
         return (() => {
           const result1 = [];
           while (offset < lcbSttbfBkmk) {
@@ -97,34 +100,34 @@ var WordExtractor = (function() {
           return result1;
         })();
       };
-  
-  
+
+
       writePieces = function(buffer, tableBuffer, result) {
         let flag;
         let pos = buffer.readUInt32LE(0x01a2);
-  
+
         while (true) {                          // eslint-disable-line no-constant-condition
           flag = tableBuffer.readUInt8(pos);
           if (flag !== 1) { break; }
-  
+
           pos = pos + 1;
           const skip = tableBuffer.readUInt16LE(pos);
           pos = pos + 2 + skip;
         }
-  
+
         flag = tableBuffer.readUInt8(pos);
         pos = pos + 1;
         if (flag !== 2) {
           throw new Error("Internal error: ccorrupted Word file");
         }
-  
+
         const pieceTableSize = tableBuffer.readUInt32LE(pos);
         pos = pos + 4;
-  
+
         const pieces = (pieceTableSize - 4) / 12;
         let start = 0;
         let lastPosition = 0;
-  
+
         return (() => {
           const result1 = [];
           for (let x = 0, end = pieces - 1; x <= end; x++) {
@@ -140,38 +143,38 @@ var WordExtractor = (function() {
             const lStart = tableBuffer.readUInt32LE(pos + (x * 4));
             const lEnd = tableBuffer.readUInt32LE(pos + ((x + 1) * 4));
             const totLength = lEnd - lStart;
-  
+
             const piece = {
               start,
               totLength,
               filePos,
               unicode
             };
-  
+
             getPiece(buffer, piece);
             piece.length = piece.text.length;
             piece.position = lastPosition;
             piece.endPosition = lastPosition + piece.length;
             result.pieces.push(piece);
-  
+
             start = start + (unicode ? Math.floor(totLength / 2) : totLength);
             result1.push(lastPosition = lastPosition + piece.length);
           }
           return result1;
         })();
       };
-  
+
       extractWordDocument = (document, buffer) =>
         new Promise(function(resolve, reject) {
           const magic = buffer.readUInt16LE(0);
           if (magic !== 0xa5ec) {
             return reject(new Error(`This does not seem to be a Word document: Invalid magic number: ${magic.toString(16)}`));
           }
-  
+
           const flags = buffer.readUInt16LE(0xA);
-  
+
           const table = (flags & 0x0200) !== 0 ? "1Table" : "0Table";
-  
+
           return documentStream(document, table)
             .then(stream => streamBuffer(stream)).then(function(tableBuffer) {
               const result = new Document();
@@ -180,47 +183,47 @@ var WordExtractor = (function() {
               result.boundaries.ccpFtn = buffer.readUInt32LE(0x0050);
               result.boundaries.ccpHdd = buffer.readUInt32LE(0x0054);
               result.boundaries.ccpAtn = buffer.readUInt32LE(0x005c);
-  
+
               writeBookmarks(buffer, tableBuffer, result);
               writePieces(buffer, tableBuffer, result);
-  
+
               return resolve(result);}).catch(error => reject(error));
         })
       ;
-  
-  
+
+
       getPiece = function(buffer, piece) {
         const pstart = piece.start;
         const ptotLength = piece.totLength;
         const pfilePos = piece.filePos;
         const punicode = piece.unicode;
-  
+
         const pend = pstart + ptotLength;
         const textStart = pfilePos;
         const textEnd = textStart + (pend - pstart);
-  
+
         if (punicode) {
           return piece.text = addUnicodeText(buffer, textStart, textEnd);
         } else {
           return piece.text = addText(buffer, textStart, textEnd);
         }
       };
-  
-  
+
+
       addText = function(buffer, textStart, textEnd) {
         const slice = buffer.slice(textStart, textEnd);
         return slice.toString('binary');
       };
-  
+
       addUnicodeText = function(buffer, textStart, textEnd) {
         const slice = buffer.slice(textStart, (2*textEnd) - textStart);
         const string = slice.toString('ucs2');
-  
+
         // See the conversion table for FcCompressed structures. Note that these
         // should not affect positions, as these are characters now, not bytes
         // for i in [0..string.length]
         //   if
-  
+
         return string;
       };
     }


### PR DESCRIPTION
@morungos - a couple questions

 - I tried to only add buffer support onto the existing `ole-doc.js` but realized it may make sense to remove file support from `ole-doc.js` and always pass it a buffer.  This would remove the `base -> file | buffer` constructors.  Then from `word.js` we could read a file and pass ole-doc the resulting buffer.  This would also simplify the tests because we'd only have to test buffers.

 - If you don't want to do that, then how would you like to handle tests?  I could write a helper which takes a filename and a test callback which it then uses to test both file and buffer support.  I just know some people prefer tests to be free from too much abstraction, in which case I could also just copy/paste the tests.  I don't care either way.