### PR TITLE
Clarify supports only DOC, not DOCX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ### word-extractor
 
-Read data from a Word document using node.js
+Read data from a Word document using node.js.
 
+Important note: this project supports the original Word .doc format, not its .docx successor.
 
 #### Why use this module?
 


### PR DESCRIPTION
I'd like to save people some time. Almost all current users will want support for DOCX and it's not obvious that this project only supports legacy DOC format, not DOCX.